### PR TITLE
Fix post-package-install

### DIFF
--- a/App/Setup/InstallSymlinks.php
+++ b/App/Setup/InstallSymlinks.php
@@ -14,7 +14,7 @@ use Composer\Script\Event;
  */
 class InstallSymlinks
 {
-    public static function postPackageInstall(Event $event)
+    public static function postInstall(Event $event)
 	{
 		$bsImagePath = '../../vendor/twitter/bootstrap/docs/assets/img';
 		$imgAssetsPath = 'www/assets/img';

--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,8 @@
 		"filp/whoops": "1.0.7"
 	},
     "scripts": {
-        "post-package-install": [
-            "App\\Setup\\InstallSymlinks::postPackageInstall"
+        "post-install-cmd": [
+            "App\\Setup\\InstallSymlinks::postInstall"
         ]
     },
     "autoload": {


### PR DESCRIPTION
It updates the post-package-install script to post-install-cmd. It currently fatal errors since it's trying to symlink non-existent folders (until after twitter/bootstrap is installed). The post-package-install runs after every package install, and there's not good documentation on how to use it properly in order to get the last installed package (in this case, to only run it after twitter/bootstrap). So for now, I think this should be as a post-install-cmd.
